### PR TITLE
Fix mistake of argument for git command

### DIFF
--- a/lib/command-runner.coffee
+++ b/lib/command-runner.coffee
@@ -45,7 +45,7 @@ class CommandRunner
         )).join(" ")
       ]
     else
-      [@command]
+      @args
 
   # These "darwin" check is a workaround for a Yosemite bug. See
   # http://stackoverflow.com/questions/24022582/osx-10-10-yosemite-beta-on-git-pull-git-sh-setup-no-such-file-or-directory/24044478


### PR DESCRIPTION
The mistake had affected except Mac OS: Windows and Linux.